### PR TITLE
Add .gitignore and enhance akshare_datafeed.py for interval handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual Environment
+venv/
+ENV/
+env/
+.env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Project specific
+*.log
+.coverage
+htmlcov/
+.pytest_cache/
+.tox/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Local development settings
+local_settings.py 
+
+vnpy_akshare.egg-info/


### PR DESCRIPTION
- Created a .gitignore file to exclude common Python and project-specific files.
- Updated akshare_datafeed.py to support hourly data retrieval alongside minute data.
- Introduced INTERVAL_DELTA_MAP for better interval management.
- Improved error handling for data queries, ensuring proper datetime parsing.

本地打包，并在trader上面，获取数据并进行回测。

vnpy trader数据有点坑，只支持分钟、小时、日，不支持周及以上，可以下载，但是打开的时候会报错。
